### PR TITLE
add OpenSaaS.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ List of SaaS boilerplates (starter kits) by stack
 
 ## Node.js (Javascript)
 
+- OpenSaaS.sh - free, open-source React/NodeJS/Prisma/Stripe SaaS boilerplate [https://OpenSaaS.sh/](https://opensaas.sh?utm_source=awesome-saas-boilerplates)
 - LaunchFa.st - Astro SaaS Boilerplate [https://launchfa.st/](https://launchfa.st/?utm_source=awesome-saas-boilerplates)
 - BoilerCode - SaaS Boilerplate [https://boilercode.co/](https://boilercode.co/?utm_source=awesome-saas-boilerplates)
 - Widin [https://widin.io/](https://widin.io/?utm_source=awesome-saas-boilerplates&utm_medium=catalog)


### PR DESCRIPTION
OpenSaaS.sh is a free, open-source React/NodeJS/Prisma full-stack SaaS boilerplate with tons of features:

- auth
- cron jobs
- admin dasboard
- landing page
- plausible or google analytics
- stripe integration
- openAI API examples
- deployable anywhere (NO VENDER LOCK-IN)